### PR TITLE
Fix client-side navigation with NextUI/Link

### DIFF
--- a/renderer/PageShell.jsx
+++ b/renderer/PageShell.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { navigate } from 'vike/client/router'
 import PropTypes from 'prop-types'
 import './PageShell.css'
 import {NextUIProvider} from '@nextui-org/react'
@@ -16,7 +17,8 @@ function PageShell({pageContext, children}) {
 
     return (
         <React.StrictMode>
-            <NextUIProvider>
+            {/* See https://nextui.org/docs/guide/routing */}
+            <NextUIProvider navigate={navigate}>
                 <PageContextProvider pageContext={pageContext}>
                         <PageBackdropProvider>
                             <Layout>


### PR DESCRIPTION
I'm a bit surprised by having to do that, but at least this is in line with what the docs say:

1. https://nextui.org/docs/components/link#routing tells me to set up the routing
2. https://nextui.org/docs/guide/routing#nextuiprovider-setup tells me to pass a `navigate` function to `<NextUIProvider>`

Again, not sure why NextUI needs that, but it then works :)